### PR TITLE
fixup/scanning: fixes for key scanning and reporting

### DIFF
--- a/src/key_scanner.rs
+++ b/src/key_scanner.rs
@@ -7,7 +7,7 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, 
 use avr_device::asm;
 use usbd_hid::descriptor::KeyboardReport;
 
-use crate::{key_is_modifier, key_to_modifier, KeyMatrix, COLS, COL_KEYS, ROWS};
+use crate::{key_is_modifier, key_to_modifier, KeyMatrix, COL_KEYS, ROWS};
 
 /// Maximum number of columns of in a [RowState].
 pub const MAX_COLS: usize = 16;
@@ -260,7 +260,7 @@ impl Debounce {
         // Update state: in this case use xor to flip any bit that is true in changes.
         self.debounced ^= changes;
 
-        changes.into()
+        changes
     }
 }
 
@@ -406,10 +406,10 @@ impl KeyScanner {
         let mut keycodes = 0;
 
         for (row, row_state) in self.matrix_state.iter_mut().enumerate() {
-            for col in 0..COLS {
+            for (col, col_keys) in COL_KEYS.iter().enumerate() {
                 if row_state.previous.column(col) || row_state.current.column(col) {
                     // read the key value from the key map
-                    let key = COL_KEYS[col][row];
+                    let key = col_keys[row];
 
                     if key_is_modifier(key) {
                         reports[report_idx].modifier |= key_to_modifier(key);

--- a/src/key_scanner.rs
+++ b/src/key_scanner.rs
@@ -2,6 +2,8 @@
 //!
 //! Types and functionality for scanning the key matrix, and debouncing key activation state.
 
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
+
 use avr_device::asm;
 use usbd_hid::descriptor::KeyboardReport;
 
@@ -154,6 +156,56 @@ impl From<RowState> for u16 {
     }
 }
 
+impl BitAnd for RowState {
+    type Output = RowState;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        (self.0 & rhs.0).into()
+    }
+}
+
+impl BitAndAssign for RowState {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl BitOr for RowState {
+    type Output = RowState;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        (self.0 | rhs.0).into()
+    }
+}
+
+impl BitOrAssign for RowState {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitXor for RowState {
+    type Output = RowState;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        (self.0 ^ rhs.0).into()
+    }
+}
+
+impl BitXorAssign for RowState {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.0 ^= rhs.0;
+    }
+}
+
+impl Not for RowState {
+    type Output = RowState;
+
+    fn not(self) -> Self::Output {
+        (!self.0).into()
+    }
+}
+
 /// Debounce state for the keyscanner matrix.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Debounce {
@@ -194,19 +246,19 @@ impl Debounce {
     pub fn debounce(&mut self, sample: RowState) -> RowState {
         // Use xor to detect changes from last stable state:
         // if a key has changed, its bit will be 1, otherwise 0
-        let delta = sample.as_inner() ^ self.debounced.as_inner();
+        let delta = sample ^ self.debounced;
 
         // Increment counters and reset any unchanged bits:
         // increment bit 1 for all changed keys
-        self.db1 = RowState::from((self.db1.as_inner() ^ self.db0.as_inner()) & delta);
+        self.db1 = (self.db1 ^ self.db0) & delta;
         // increment bit 0 for all changed keys
-        self.db0 = RowState::from((!self.db0.as_inner()) & delta);
+        self.db0 = !self.db0 & delta;
 
         // Calculate returned change set: if delta is still true
         // and the counter has wrapped back to 0, the key is changed.
-        let changes = !(!delta | (self.db0.as_inner() | self.db1.as_inner()));
+        let changes = !(!delta | self.db0 | self.db1);
         // Update state: in this case use xor to flip any bit that is true in changes.
-        self.debounced = RowState::from(self.debounced.as_inner() ^ changes);
+        self.debounced ^= changes;
 
         changes.into()
     }
@@ -386,14 +438,6 @@ impl KeyScanner {
         reports
     }
 
-    fn clear_matrix_state(&mut self) {
-        for row_state in self.matrix_state.iter_mut() {
-            row_state.set_previous(RowState::new());
-            row_state.set_current(RowState::new());
-            row_state.debouncer.debounced = RowState::new();
-        }
-    }
-
     /// Perform a debounced [KeyMatrix] scan, and return any [KeyboardReport]s.
     pub fn scan<const N: usize>(&mut self) -> [KeyboardReport; N] {
         let do_scan = self.do_scan;
@@ -404,12 +448,6 @@ impl KeyScanner {
             self.do_scan = false;
         }
 
-        let reports = self.matrix_scan_reports::<N>();
-
-        if do_scan {
-            self.clear_matrix_state();
-        }
-
-        reports
+        self.matrix_scan_reports::<N>()
     }
 }

--- a/src/key_scanner.rs
+++ b/src/key_scanner.rs
@@ -408,12 +408,6 @@ impl KeyScanner {
         for (row, row_state) in self.matrix_state.iter_mut().enumerate() {
             for col in 0..COLS {
                 if row_state.previous.column(col) || row_state.current.column(col) {
-                    // If the keypress is not a held key, add an additional small delay to ensure
-                    // any following read is an intentional hold.
-                    if !row_state.previous.column(col) && row_state.current.column(col) {
-                        small_delay(384);
-                    }
-
                     // read the key value from the key map
                     let key = COL_KEYS[col][row];
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 pub struct RawSpinLock(AtomicBool);
 
 unsafe impl lock_api::RawRwLock for RawSpinLock {
+    #[allow(clippy::declare_interior_mutable_const)]
     const INIT: RawSpinLock = RawSpinLock(AtomicBool::new(false));
 
     type GuardMarker = lock_api::GuardSend;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ fn main() -> ! {
         &*USB_BUS.insert(UsbBus::new(usb))
     };
 
-    let hid_class = HIDClass::new(&usb_bus, KeyboardReport::desc(), 1);
-    let usb_device = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x1209, 0x2303))
+    let hid_class = HIDClass::new(usb_bus, KeyboardReport::desc(), 1);
+    let usb_device = UsbDeviceBuilder::new(usb_bus, UsbVidPid(0x1209, 0x2303))
         .manufacturer("Keyboardio")
         .product("Trove Atreus")
         .build();

--- a/src/std_stub.rs
+++ b/src/std_stub.rs
@@ -23,4 +23,4 @@ fn panic(_info: &PanicInfo) -> ! {
 
 #[lang = "eh_personality"]
 #[no_mangle]
-pub unsafe extern "C" fn rust_eh_personality() -> () {}
+pub unsafe extern "C" fn rust_eh_personality() {}

--- a/src/usb_context.rs
+++ b/src/usb_context.rs
@@ -30,7 +30,9 @@ impl UsbContext {
                 self.hid_class.pull_raw_output(&mut report_buf).ok();
             }
 
-            self.poll();
+            if report.modifier != 0 || report.keycodes != [0; 6] {
+                self.poll();
+            }
         }
     }
 


### PR DESCRIPTION
Adds bit-wise and logical operator implementations for convenience, and readability.

Fixes an error in the order of operations in `DebounceRowState::debounce` that caused the key activation to register incorrectly. With this fix, the `KeyScanner::clear_debouncer` function is no longer needed, and is removed.

Conditionally sends an additional blank key report poll to the host when a non-blank report is scanned.

This prevents the host interpreting the reports as key release reports when a key is being held down.

Removes unnecessary additional delay in `KeyScanner::scan_matrix`.

